### PR TITLE
Fix spacer length annotation for `XLMOD:02258`

### DIFF
--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -6131,7 +6131,8 @@ id: XLMOD:02258
 name: PhoX
 def: "PhoX cross-linker." [PMID:31477730]
 property_value: reactionSites: "2" xsd:nonNegativeInteger
-property_value: spacerLength: "5.0-20.0" xsd:float
+property_value: minSpacerLength "5.0" xsd:float
+property_value: maxSpacerLength "20.0" xsd:float
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_handle XLMOD:00173 ! phosphonic acid
 relationship: has_reactive_group XLMOD:00101 ! NHS ester

--- a/XLMOD.owl
+++ b/XLMOD.owl
@@ -20204,8 +20204,9 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PhoX cross-linker.</obo:IAO_0000115>
+        <obo:minSpacerLength rdf:datatype="http://www.w3.org/2001/XMLSchema#float">5.0</obo:minSpacerLength>
+        <obo:maxSpacerLength rdf:datatype="http://www.w3.org/2001/XMLSchema#float">20.0</obo:maxSpacerLength>
         <obo:reactionSites_ rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</obo:reactionSites_>
-        <obo:spacerLength_ rdf:datatype="http://www.w3.org/2001/XMLSchema#float">5.0-20.0</obo:spacerLength_>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">XLMOD</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">XLMOD:02258</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PhoX</rdfs:label>


### PR DESCRIPTION
This PR fixes #1.

You may want to regenerate the OWL file with a recent version of [ROBOT](https://github.com/ontodev/robot), this will remove all the `xsd:string` datatypes (since they are the default) and in general make the file a bit smaller.
