### PR TITLE
Add DSSO stubs with formula

### DIFF
--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -4652,6 +4652,8 @@ property_value: bridgeFormula: "C6 O3 S1 H6" xsd:string
 property_value: monoIsotopicMass: "158.0037648" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "10.1" xsd:float
+property_value: CID_Fragment: "H1 C3 -N1 O3 S1" xsd:string
+property_value: CID_Fragment: "H1 C3 -N1 O2" xsd:string
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_cleavable XLMOD:00067 ! CID cleavable C-S bond


### PR DESCRIPTION
Add the stubs for DSSO. Sparked by the discussion during the PSI call. The discussion that has to be had still is how to specify these as molecular formula, currently `CID_Fragment` always is a float that specifies the monoisotopic mass. If we can decide what the correct format is I can add some more definitions that I have lying around.