### PR TITLE
Added definition for enzymatic cross-linkers

### DIFF
--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -10346,7 +10346,7 @@ is_a: XLMOD:09318 ! enzymatic generated cross-link
 id: XLMOD:09320
 name: QKiso
 def: "epsilon-(gamma-L-Glutamyl)lysine" [PubChem_Compound:4093968, PubChem CID:7015685, Unimod:2026, ChemSpider ID:5378717, CAS Registry Number:17105-15-6, CHEBI:133752]
-synonym: "Xlink:KQisopeptide" EXACT []
+synonym: "Xlink:QKisopeptide" EXACT []
 synonym: "TG-XL" EXACT []
 synonym: "TG" EXACT []
 synonym: "QK-XL" EXACT []


### PR DESCRIPTION
Closes #5.

I made IDs for all new terms (added sequentially after all current items). Merged the duplicate `def` of `transglutaminase generated`. Updated the version to reflect the standard way of doing versioning in Obo. I did not know what to do with `relationship: is_reactive_with XLMOD:????? ! glutamine reactive` I might have missed some discussion that occurred during the meeting but this does not seem to be how the other cross-linkers are defined.