### PR TITLE
Added `is_labelled_version_of` relationship to replace `doubletDeltaMass`

### DIFF
--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -3121,38 +3121,38 @@ id: XLMOD:02002
 name: DSS-d4
 def: "Deuterium labelled disuccinimidyl 2,2,7,7-suberate." [PubChem_Compound:91757798, PMID:11354472]
 property_value: bridgeFormula: "C8 D4 H6 O2" xsd:string
-property_value: doubletDeltaMass: "4.02508" xsd:double
 property_value: monoIsotopicMass: "142.093186586" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "11.4" xsd:float
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02001 ! DSS
 
 [Term]
 id: XLMOD:02003
 name: DSS-d12
 def: "Deuterium labelled disuccinimidyl 2,2,3,3,4,4,5,5,6,6,7,7-suberate." [PSI:XL, PMID:11354472, PMID:16944939]
 property_value: bridgeFormula: "C8 D10 O2" xsd:string
-property_value: doubletDeltaMass: "12.07573" xsd:double
 property_value: monoIsotopicMass: "150.143400538" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "11.4" xsd:float
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02001 ! DSS
 
 [Term]
 id: XLMOD:02004
 name: BS3-d4
 def: "Deuterium labelled (bis(sulfosuccinimidyl) 2,2,7,7-suberate)." [PubChem_Compound:91757801]
-property_value: doubletDeltaMass: "4.02508" xsd:double
 property_value: monoIsotopicMass: "142.093186586" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "11.4" xsd:float
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00102 ! Sulfo NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02000 ! BS3
 
 [Term]
 id: XLMOD:02005
@@ -3193,7 +3193,6 @@ id: XLMOD:02007
 name: DSG-d4
 def: "Deuterium labelled disuccinimidyl 2,2,4,4-glutarate." [PubChem_Compound:91757797]
 property_value: bridgeFormula: "C5 D4 O2" xsd:string
-property_value: doubletDeltaMass: "4.02508" xsd:double
 property_value: monoIsotopicMass: "100.046236376" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "7.7" xsd:float
@@ -3201,6 +3200,7 @@ is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_property XLMOD:00013 ! membrane permeable
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02006 ! DSG
 
 [Term]
 id: XLMOD:02008
@@ -3208,13 +3208,13 @@ name: BS2G-d4
 def: "Deuterium labelled bis(sulfosuccinimidyl) 2,2,4,4-glutarate." [PubChem_Compound:91757799]
 synonym: "DSSG-d4" EXACT []
 property_value: bridgeFormula: "C5 D4 O2" xsd:string
-property_value: doubletDeltaMass: "4.02508" xsd:double
 property_value: monoIsotopicMass: "100.046236376" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "7.7" xsd:float
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00102 ! Sulfo NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02005 ! BS2G
 
 [Term]
 id: XLMOD:02009
@@ -3511,7 +3511,6 @@ id: XLMOD:02030
 name: DSP-d8
 def: "Deuterium labelled Dithiobis[1,1,2,2,2,2,3,3-succinimidyl propionate." [PubChem_Compound:91757796]
 property_value: bridgeFormula: "C6 D6 O2 S2" xsd:string
-property_value: doubletDeltaMass: "8.05016" xsd:double
 property_value: monoIsotopicMass: "182.0314167" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "12.0" xsd:float
@@ -3520,6 +3519,7 @@ relationship: has_property XLMOD:00013 ! membrane permeable
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_cleavable XLMOD:00023 ! cleavable S-S bond
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02029 ! DSP
 
 [Term]
 id: XLMOD:02031
@@ -3744,7 +3744,6 @@ id: XLMOD:02048
 name: DTSSP-d8
 def: "Deuterium labelled 3,3'-Dithiobis[sulfosuccinimidylpropionate]." [PMID:10975572, PMID:18510349]
 property_value: bridgeFormula: "C6 D6 O2 S2" xsd:string
-property_value: doubletDeltaMass: "8.05016" xsd:double
 property_value: monoIsotopicMass: "182.03109" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "12.0" xsd:float
@@ -3754,13 +3753,13 @@ relationship: has_reactive_group XLMOD:00102 ! Sulfo NHS ester
 relationship: is_cleavable XLMOD:00023 ! cleavable S-S bond
 relationship: is_cleavable XLMOD:00035 ! CID cleavable
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02033 ! DTSSP
 
 [Term]
 id: XLMOD:02049
 name: EGS-d12
 def: "Deuterium labelled ethylene glycolbis(succinimidylsuccinate)." [PMID:15901824]
 property_value: bridgeFormula: "C10 D10 O6" xsd:string
-property_value: doubletDeltaMass: "12.07573" xsd:double
 property_value: monoIsotopicMass: "238.12347" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "16.1" xsd:float
@@ -3770,13 +3769,13 @@ relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_cleavable XLMOD:00025 ! hydroxylamine cleavable
 relationship: is_cleavable XLMOD:00039 ! ammonium cleavable
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02034 ! EGS
 
 [Term]
 id: XLMOD:02050
 name: Sulfo-EGS-d12
 def: "Deuterium labelled ethylene glycolbis(sulfosuccinimidylsuccinate)." [PMID:15901824]
 property_value: bridgeFormula: "C10 D10 O6" xsd:string
-property_value: doubletDeltaMass: "12.07573" xsd:double
 property_value: monoIsotopicMass: "238.12347" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "16.1" xsd:float
@@ -3786,6 +3785,7 @@ relationship: has_reactive_group XLMOD:00102 ! Sulfo NHS ester
 relationship: is_cleavable XLMOD:00025 ! hydroxylamine cleavable
 relationship: is_cleavable XLMOD:00039 ! ammonium cleavable
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02035 ! Sulfo-EGS
 
 [Term]
 id: XLMOD:02051
@@ -3805,31 +3805,30 @@ name: PCAS-d4
 def: "Pyridine-3-Carboxylic Acid Succinimide." [PMID:20050626, PMID:23085224]
 synonym: "PCASS-d4" EXACT []
 property_value: bridgeFormula: "C6 D3 N1 O1" xsd:string
-property_value: doubletDeltaMass: "4.02508" xsd:double
 property_value: monoIsotopicMass: "109.04812" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02051 ! PCAS
 
 [Term]
 id: XLMOD:02053
 name: DSA-13C6
 def: "13C labelled disuccinimidyladipic acid." [PSI:XL]
 property_value: bridgeFormula: "13C6 H6 O2" xsd:string
-property_value: doubletDeltaMass: "6.02016" xsd:double
 property_value: monoIsotopicMass: "116.0564" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_property XLMOD:00013 ! membrane permeable
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_labelled XLMOD:00036 ! 13C labelled
+relationship: is_labelled_version_of XLMOD:02043 ! DSA
 
 [Term]
 id: XLMOD:02054
 name: CBDPS-d8
 def: "Deuterium labelled cyanurbiotindipropionylsuccinimide." [PMID:20622150]
 property_value: bridgeFormula: "C19 D8 H15 N7 O4 S3" xsd:string
-property_value: doubletDeltaMass: "8.05016" xsd:double
 property_value: monoIsotopicMass: "517.14698" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "14.0" xsd:float
@@ -3839,6 +3838,7 @@ relationship: has_property XLMOD:00014 ! hydrophilic
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_cleavable XLMOD:00035 ! CID cleavable
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:03001 ! CBDPS
 
 [Term]
 id: XLMOD:02055
@@ -3860,7 +3860,6 @@ id: XLMOD:02056
 name: CBDPSS-d8
 def: "Deuterium labelled cyanurbiotindimercaptopropionylsulfosuccinimide." [PMID:20622150]
 property_value: bridgeFormula: "C19 D8 H15 N7 O4 S3" xsd:string
-property_value: doubletDeltaMass: "8.05016" xsd:double
 property_value: monoIsotopicMass: "517.14698" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "14.0" xsd:float
@@ -3870,6 +3869,7 @@ relationship: has_property XLMOD:00014 ! hydrophilic
 relationship: has_reactive_group XLMOD:00102 ! Sulfo NHS ester
 relationship: is_cleavable XLMOD:00035 ! CID cleavable
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02055 ! CBDPSS
 
 [Term]
 id: XLMOD:02057
@@ -3886,12 +3886,12 @@ id: XLMOD:02058
 name: SDH-d12
 def: "Deuterium labelled suberic acid 1,8-dihydrazide." [PMID:24938783]
 property_value: bridgeFormula: "C8 D12 H2 N4" xsd:string
-property_value: doubletDeltaMass: "12.07573" xsd:double
 property_value: monoIsotopicMass: "178.1971667418" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00110 ! hydrazide
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02057 ! SDH
 
 [Term]
 id: XLMOD:02059
@@ -3908,12 +3908,12 @@ id: XLMOD:02060
 name: ADH-d8
 def: "Deuterium labelled adipic acid 1,6-dihydrazide." [PMID:24938783]
 property_value: bridgeFormula: "C6 D8 H2 N4" xsd:string
-property_value: doubletDeltaMass: "8.05016" xsd:double
 property_value: monoIsotopicMass: "146.140760302" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00110 ! hydrazide
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02059 ! ADH
 
 [Term]
 id: XLMOD:02061
@@ -3930,18 +3930,17 @@ id: XLMOD:02062
 name: GDH-d6
 def: "Deuterium labelled glutaric acid 1,5-dihydrazide." [PMID:24938783]
 property_value: bridgeFormula: "C5 D6 H2 N4" xsd:string
-property_value: doubletDeltaMass: "6.04368" xsd:double
 property_value: monoIsotopicMass: "130.112556744" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00110 ! hydrazide
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02061 ! GDH
 
 [Term]
 id: XLMOD:02063
 name: BS3-d12
 def: "Deuterium labelled (bis(sulfosuccinimidyl) 2,2,3,3,4,4,5,5,6,6,7,7-suberate)." [PSI:XL]
-property_value: doubletDeltaMass: "12.07573" xsd:double
 property_value: monoIsotopicMass: "150.14381" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "11.4" xsd:float
@@ -3949,13 +3948,13 @@ is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_property XLMOD:00014 ! hydrophilic
 relationship: has_reactive_group XLMOD:00102 ! Sulfo NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02000 ! BS3
 
 [Term]
 id: XLMOD:02064
 name: DSG-d6
 def: "Deuterium labelled disuccinimidyl 2,2,3,3,4,4-glutarate." [PSI:XL]
 property_value: bridgeFormula: "C5 D6 O2" xsd:string
-property_value: doubletDeltaMass: "6.02016" xsd:double
 property_value: monoIsotopicMass: "102.05821" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "7.7" xsd:float
@@ -3963,6 +3962,7 @@ is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_property XLMOD:00013 ! membrane permeable
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02006 ! DSG
 
 [Term]
 id: XLMOD:02065
@@ -3970,7 +3970,6 @@ name: BS2G-d6
 def: "Deuterium labelled bis(sulfosuccinimidyl) 2,2,3,3,4,4-glutarate." [PSI:XL]
 synonym: "DSSG-d6" EXACT []
 property_value: bridgeFormula: "C5 D4 O2" xsd:string
-property_value: doubletDeltaMass: "4.02508" xsd:double
 property_value: monoIsotopicMass: "100.046236376" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "7.7" xsd:float
@@ -3978,6 +3977,7 @@ is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_property XLMOD:00014 ! hydrophilic
 relationship: has_reactive_group XLMOD:00102 ! Sulfo NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02005 ! BS2G
 
 [Term]
 id: XLMOD:02066
@@ -4469,13 +4469,13 @@ id: XLMOD:02110
 name: SBDC
 def: "Deuterium labelled N-succinimidyl p-benzoyldihydrocinnamate." [PMID:19653199]
 synonym: "SBC-d2" EXACT []
-property_value: doubletDeltaMass: "2.01254" xsd:double
 property_value: monoIsotopicMass: "238.10" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00006 ! heterofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: has_reactive_group XLMOD:00119 ! benzophenone
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02109 ! SBC
 
 [Term]
 id: XLMOD:02111

--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -3806,7 +3806,7 @@ id: XLMOD:02052
 name: PCAS-d4
 def: "Pyridine-3-Carboxylic Acid Succinimide." [PMID:20050626, PMID:23085224]
 synonym: "PCASS-d4" EXACT []
-property_value: bridgeFormula: "C6 D4 N1 O1" xsd:string
+property_value: deadEndFormula: "C6 D4 N1 O1" xsd:string
 property_value: monoIsotopicMass: "110.054340" xsd:double
 property_value: reactionSites: "1" xsd:nonNegativeInteger
 relationship: is_labelled XLMOD:00010 ! deuterium labelled

--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
 data-version: 1.5.4
 ontology: xlmod
-date: 24:04:2026 17:36
+date: 29:04:2026 10:29
 saved-by: Douwe Schulte
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: XLMOD
@@ -3794,22 +3794,25 @@ def: "Pyridine-3-Carboxylic Acid Succinimide." [PMID:20050626, PMID:23085224]
 synonym: "PCAS-H4" EXACT []
 synonym: "PCAS-d0" EXACT []
 synonym: "PCASS" EXACT []
-property_value: bridgeFormula: "C6 H3 N1 O1" xsd:string
-property_value: monoIsotopicMass: "105.02146" xsd:double
-property_value: reactionSites: "2" xsd:nonNegativeInteger
-is_a: XLMOD:00005 ! homofunctional cross-linker
+synonym: "PyridineCarboxylicAcidSuccinimide" EXACT []
+property_value: deadEndFormula: "C6 H4 N1 O1" xsd:string
+property_value: monoIsotopicMass: "106.029289" xsd:double
+property_value: reactionSites: "1" xsd:nonNegativeInteger
+relationship: is_reactive_with XLMOD:00028 ! primary amine reactive
+relationship: is_reactive_with XLMOD:06503 ! amino acid reactive
 
 [Term]
 id: XLMOD:02052
 name: PCAS-d4
 def: "Pyridine-3-Carboxylic Acid Succinimide." [PMID:20050626, PMID:23085224]
 synonym: "PCASS-d4" EXACT []
-property_value: bridgeFormula: "C6 D3 N1 O1" xsd:string
-property_value: monoIsotopicMass: "109.04812" xsd:double
-property_value: reactionSites: "2" xsd:nonNegativeInteger
-is_a: XLMOD:00005 ! homofunctional cross-linker
+property_value: bridgeFormula: "C6 D4 N1 O1" xsd:string
+property_value: monoIsotopicMass: "110.054340" xsd:double
+property_value: reactionSites: "1" xsd:nonNegativeInteger
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
 relationship: is_labelled_version_of XLMOD:02051 ! PCAS
+relationship: is_reactive_with XLMOD:00028 ! primary amine reactive
+relationship: is_reactive_with XLMOD:06503 ! amino acid reactive
 
 [Term]
 id: XLMOD:02053
@@ -9587,7 +9590,7 @@ def: "(S)-2,5-dioxopyrrolidin-1-yl-1-(4,6-dimethoxy-1,3,5-triazin-2-yl) pyrrolid
 synonym: "DMT-(S)-Pro-OSu" EXACT []
 is_a: XLMOD:06009 ! chiral derivatization reagent
 is_a: XLMOD:06010 ! LCMS derivatization reagent
-relationship: is_reactive_with XLMOD:00028 ! amino reactice
+relationship: is_reactive_with XLMOD:00028 ! primary amine reactive
 relationship: is_reactive_with XLMOD:06503 ! amino acid reactive
 
 [Term]
@@ -9606,7 +9609,7 @@ def: "(R)-2,5-dioxopyrrolidin-1-yl-1-(4,6-dimethoxy-1,3,5-triazin-2-yl) pyrrolid
 synonym: "DMT-(R)-Pro-OSu" EXACT []
 is_a: XLMOD:06009 ! chiral derivatization reagent
 is_a: XLMOD:06010 ! LCMS derivatization reagent
-relationship: is_reactive_with XLMOD:00028 ! amino reactice
+relationship: is_reactive_with XLMOD:00028 ! primary amine reactive
 relationship: is_reactive_with XLMOD:06503 ! amino acid reactive
 
 [Term]

--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -95,6 +95,11 @@ id: has_reactive_group
 name: has_reactive_group
 def: "Indicates that the cross-linking or derivatization reagent has the specified reactive group." [OBO:defs]
 
+[Typedef]
+id: is_labelled_version_of
+name: is_labelled_version_of
+def: "Indicates that the cross-linking reagent is a labelled version of the indicated reagent." [OBO:defs]
+
 [Term]
 id: XLMOD:00000
 name: Proteomics Standards Initiative cross-linking and derivatization controlled vocabulary
@@ -2330,12 +2335,12 @@ id: XLMOD:01095
 name: hydrolyzed PDH-d10
 def: "Deuterium labelled hydrolyzed pimelic acid dihydrazide." [PSI:XL]
 property_value: bridgeFormula: "C7 D10 H2 N4" xsd:string
-property_value: doubletDeltaMass: "10.06276744" xsd:double
 property_value: monoIsotopicMass: "180.17952856" xsd:double
 is_a: XLMOD:00096 ! hydrolization cross-linker related chemical modification
 relationship: is_partially_reacted XLMOD:00011 ! hydrolyzed
 relationship: is_side_product_of XLMOD:02224 ! PDH-d10
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:01094 ! hydrolyzed PDH
 
 [Term]
 id: XLMOD:01096

--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -4591,7 +4591,6 @@ synonym: "Disuccinimidyl dibutyric urea" EXACT []
 synonym: "DSBU" EXACT []
 property_value: bridgeFormula: "C9 H12 N2 O3" xsd:string
 property_value: monoIsotopicMass: "196.084792" xsd:double
-property_value: doubletDeltaMass: "25.979" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "12.5" xsd:float
 property_value: stubDefinition "CID =  : C9 H12 N2 O3" xsd:string
@@ -5608,12 +5607,12 @@ id: XLMOD:02210
 name: PDH-d10
 def: "Deuterium labelled pimelic acid dihydrazide." [PSI:XL]
 property_value: bridgeFormula: "C7 D10 H2 N4" xsd:string
-property_value: doubletDeltaMass: "10.06276744" xsd:double
 property_value: monoIsotopicMass: "162.16896386" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00110 ! hydrazide
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
+relationship: is_labelled_version_of XLMOD:02209 ! PDH
 
 [Term]
 id: XLMOD:02211
@@ -5629,13 +5628,13 @@ relationship: has_reactive_group XLMOD:00055 ! azide
 id: XLMOD:02212
 name: ABAS-13C6
 def: "13C labelled azidobenzoic acid succinimide." [PMID:25192908]
-property_value: doubletDeltaMass: "6.02016" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "7.0" xsd:float
 is_a: XLMOD:00006 ! heterofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: has_reactive_group XLMOD:00055 ! azide
 relationship: is_labelled XLMOD:00036 ! 13C labelled
+relationship: is_labelled_version_of XLMOD:02211 ! ABAS
 
 [Term]
 id: XLMOD:02213
@@ -5651,20 +5650,19 @@ relationship: has_reactive_group XLMOD:00119 ! benzophenone
 id: XLMOD:02214
 name: CBS-13C6
 def: "13C labelled carboxy-benzophenone-succinimide." [PMID:25192908]
-property_value: doubletDeltaMass: "6.02016" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "7.0" xsd:float
 is_a: XLMOD:00006 ! heterofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: has_reactive_group XLMOD:00119 ! benzophenone
 relationship: is_labelled XLMOD:00036 ! 13C labelled
+relationship: is_labelled_version_of XLMOD:02213 ! CBS
 
 [Term]
 id: XLMOD:02215
 name: SDA-13C5
 def: "13C labelled succinimidyl-ester diazirine." [PMID:25192908]
 property_value: bridgeFormula: "13C5 H6 O1" xsd:string
-property_value: doubletDeltaMass: "5.0168" xsd:double
 property_value: monoIsotopicMass: "87.05866484" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "5.0" xsd:float
@@ -5672,6 +5670,7 @@ is_a: XLMOD:00006 ! heterofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: has_reactive_group XLMOD:00103 ! diazirine
 relationship: is_labelled XLMOD:00036 ! 13C labelled
+relationship: is_labelled_version_of XLMOD:02134 ! SDA
 
 [Term]
 id: XLMOD:02216
@@ -5687,12 +5686,12 @@ relationship: is_cleavable XLMOD:00067 ! CID cleavable C-S bond
 id: XLMOD:02217
 name: DMDSSO-d10
 def: "Deuterium labelled dimethyl disuccinimidyl sulfoxide." [PMID:24471733]
-property_value: doubletDeltaMass: "10.06276744" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 is_a: XLMOD:00006 ! heterofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 relationship: is_labelled XLMOD:00010 ! deuterium labelled
 relationship: is_cleavable XLMOD:00067 ! CID cleavable C-S bond
+relationship: is_labelled_version_of XLMOD:02216 ! DMDSSO
 
 [Term]
 id: XLMOD:02218
@@ -6286,13 +6285,13 @@ relationship: has_reactive_group XLMOD:00055 ! azide
 id: XLMOD:03011
 name: TATA-13C6
 def: "13C labelled 2,4,6-triazido-1,3,5-triazine." [PMID:26931439]
-property_value: doubletDeltaMass: "6.02016" xsd:double
 property_value: monoIsotopicMass: "206.07016" xsd:double
 property_value: reactionSites: "3" xsd:nonNegativeInteger
 property_value: spacerLength: "5.0" xsd:float
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00055 ! azide
 relationship: is_labelled XLMOD:00036 ! 13C labelled
+relationship: is_labelled_version_of XLMOD:03010 ! TATA
 
 [Term]
 id: XLMOD:03012

--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 1.5.3
+data-version: 1.5.4
 ontology: xlmod
-date: 27:03:2026 16:02
+date: 24:04:2026 17:36
 saved-by: Douwe Schulte
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: XLMOD


### PR DESCRIPTION
Closes #14.

Introduces a new relationship type `is_labelled_version_of` that can indicate the original for a labelled modification.

The modification `XLMOD:02120 ! BuUrBu` did contain a wrong use of doubletDeltaMass so that was removed. This usage was the difference between the two stubs instead of the difference between a labelled and unlabelled version.