### PR TITLE
Add to the information for DSS, PhoX, & DMTMM

### DIFF
--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
 data-version: 1.5.4
 ontology: xlmod
-date: 29:04:2026 10:29
+date: 16:06:2026 11:25
 saved-by: Douwe Schulte
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: XLMOD
@@ -1128,7 +1128,7 @@ relationship: is_reactive_with XLMOD:00037 ! non-selective
 id: XLMOD:00146
 name: dimethylether
 def: "A dimethylether (Ch3-O-CH3) reactive group that reacts with carboxyl groups." [PSI:XL]
-property_value: specificities: "(D,E)" xsd:string
+property_value: specificities: "(D,E,Protein C-term)" xsd:string
 is_a: XLMOD:00100 ! reactive group
 relationship: is_reactive_with XLMOD:00030 ! carboxyl reactive
 
@@ -5593,7 +5593,7 @@ def: "4-(4,6-Dimethoxy-1,3,5-triazin-2-yl)-4-methylmorpholinium chloride." [CAS:
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: bridgeFormula: "-H2 -O1" xsd:string
 property_value: monoIsotopicMass: "-18.01056027" xsd:double
-property_value: specificities: "(K)&(D,E)" xsd:string
+property_value: specificities: "(K,Protein N-term)&(D,E,Protein C-term)" xsd:string
 is_a: XLMOD:00006 ! heterofunctional cross-linker
 is_a: XLMOD:00008 ! zero-length cross-linker
 relationship: has_reactive_group XLMOD:00146 ! dimethylether

--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -3113,6 +3113,7 @@ property_value: bridgeFormula: "C8 H10 O2" xsd:string
 property_value: monoIsotopicMass: "138.06807961" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "11.4" xsd:float
+property_value: specificities "(K)" xsd:string
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 
@@ -5591,7 +5592,11 @@ id: XLMOD:02208
 name: DMTMM
 def: "4-(4,6-Dimethoxy-1,3,5-triazin-2-yl)-4-methylmorpholinium chloride." [CAS:3945-69-5, PubChem_Compound:2734059, ChemSpiderID:2015817, ChemicalBookNo:CB5695021, PMID:24938783]
 property_value: reactionSites: "2" xsd:nonNegativeInteger
-is_a: XLMOD:00005 ! homofunctional cross-linker
+property_value: bridgeFormula: "-H2 -O1" xsd:string
+property_value: monoIsotopicMass: "-18.01056027" xsd:double
+property_value: specificities: "(K)&(D,E)" xsd:string
+is_a: XLMOD:00006 ! heterofunctional cross-linker
+is_a: XLMOD:00008 ! zero-length cross-linker
 relationship: has_reactive_group XLMOD:00146 ! dimethylether
 
 [Term]
@@ -6154,6 +6159,8 @@ property_value: monoIsotopicMass: "209.971810" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: minSpacerLength "5.0" xsd:float
 property_value: maxSpacerLength "20.0" xsd:float
+property_value: neutralLossFormula "-H2 -O1" xsd:string
+property_value: specificities "(K)" xsd:string
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_handle XLMOD:00173 ! phosphonic acid
 relationship: has_reactive_group XLMOD:00101 ! NHS ester

--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -3113,7 +3113,6 @@ property_value: bridgeFormula: "C8 H10 O2" xsd:string
 property_value: monoIsotopicMass: "138.06807961" xsd:double
 property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: spacerLength: "11.4" xsd:float
-property_value: specificities "(K)" xsd:string
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_reactive_group XLMOD:00101 ! NHS ester
 
@@ -6160,7 +6159,6 @@ property_value: reactionSites: "2" xsd:nonNegativeInteger
 property_value: minSpacerLength "5.0" xsd:float
 property_value: maxSpacerLength "20.0" xsd:float
 property_value: neutralLossFormula "-H2 -O1" xsd:string
-property_value: specificities "(K)" xsd:string
 is_a: XLMOD:00005 ! homofunctional cross-linker
 relationship: has_handle XLMOD:00173 ! phosphonic acid
 relationship: has_reactive_group XLMOD:00101 ! NHS ester


### PR DESCRIPTION
I added the origins for these three cross-linkers. The neutral loss for PhoX was mentioned in the original article. DMTMM was quite underspecified so I added what I could gather.