### PR TITLE
Add TSTO

### DIFF
--- a/XLMOD.obo
+++ b/XLMOD.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: 1.5.4
+data-version: 1.5.5
 ontology: xlmod
-date: 29:04:2026 10:29
+date: 29:05:2026 17:30
 saved-by: Douwe Schulte
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: XLMOD
@@ -10378,3 +10378,15 @@ is_a: XLMOD:00008 ! zero-length cross-linker
 relationship: is_labelled XLMOD:09318 ! enzymatic generated
 relationship: is_labelled XLMOD:09319 ! transglutaminase generated
 relationship: is_reactive_with XLMOD:00028 ! primary amine reactive
+
+[Term]
+id: XLMOD:09321
+name: TSTO
+def: "Tris-succinimidyl trioxane." [PMID:40593561]
+property_value: bridgeFormula: "C15 H18 O6" xsd:string
+property_value: stubDefinition: "CID = C5 H6 O2, -H2 -O1 : C5 H6 O2, -H2 -O1 : C5 H6 O2, -H2 -O1" xsd:string
+property_value: reactionSites: "3" xsd:nonNegativeInteger
+property_value: spacerLength: "21.1" xsd:float
+property_value: maxSpacerLength: "35" xsd:float
+is_a: XLMOD:00005 ! homofunctional cross-linker
+relationship: has_reactive_group XLMOD:00101 ! NHS ester


### PR DESCRIPTION
I was searching for some trimeric cross-linkers to use for examples while working on the mzPAF cross-linking extension when I found TSTO. This seems to be a neat MS cleavable trimeric cross-linker. One issue with this however is that it might be hard to gain all possible binding motifs from this definition, only the so called 'Type I' can be well represented here I think. I would suggest to merge as is and when we actually see that this is not good enough open a discussion for how to handle multimeric cross-linkers better.
<img width="750" height="640" alt="image" src="https://github.com/user-attachments/assets/abb84bde-aaa5-44b0-87e8-8e2ec36fcad7" />
Paper: https://doi.org/10.1038/s41467-025-60642-3 
